### PR TITLE
fix: npm 배포를 위한 ESM/CJS 엔트리 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-optimistic-chat",
   "version": "1.0.0",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "peerDependencies": {
     "@tanstack/react-query": ">=5",
@@ -36,8 +36,9 @@
   "exports": {
     "./style.css": "./dist/styles/style.css",
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   }
 }


### PR DESCRIPTION
## 📌 Related Issue
#25 — **npm 배포를 위한 ESM/CJS 엔트리 분리**

## 🚀 Description
- tsup 빌드 결과에 맞게 ESM/CJS 엔트리 분리
- pakage.json의 main/module/types 설정 수정
- exports 필드 수정

## 📸 Screenshot
package.json 내부 경로 수정이므로 별도 스크린샷 없음

## 📢 Notes
- tsup 설정 변경 없이 package.json 수동 조정