### PR TITLE
fix: style.css export 경로 불일치 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.9.3"
   },
   "exports": {
-    "./style.css": "./dist/styles/style.css",
+    "./style.css": "./dist/style.css",
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",


### PR DESCRIPTION
## 📌 Related Issue
#27 — **style.css export 경로 불일치 수정**

## 🚀 Description
- package.json의 exports에서 style.css 경로를 실제 빌드 결과와 일치하도록 수정
- npm 설치 후 'import "react-optimistic-chat/style.css"' 사용 시 발생할 수 있는 런타임 에러를 사전에 방지

## 📸 Screenshot
별도의 UI 변경 없으므로 스크린샷 없음

## 📢 Notes
- files 설정은 dist만 유지
- sideEffects 설정은 별도 이슈/브랜치에서 진행 예정