### PR TITLE
fix: CSS 파일을 sideEffects로 등록하여 tree-shaking 제거 방지 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
-  }
+  },
+  "sideEffects": [
+    "./dist/style.css"
+  ]
 }


### PR DESCRIPTION
## 📌 Related Issue
#29 — **CSS 파일을 sideEffects로 등록하여 tree-shaking 제거 방지** 

## 🚀 Description
전역 CSS 파일(style.css)을 sideEffects로 명시하여 tree-shaking 과정에서 CSS가 제거되는 문제 방지

## 📸 Screenshot
설정 변경으로 별도의 스크린샷 없음

## 📢 Notes
- JS 파일은 sideEffects 대상에서 제외
- CSS 파일만 최소 범위로 지정하여 tree-shaking 영향 최소화