### PR TITLE
refactor: Message 타입 단일화 및 Raw 제네릭 네이밍 정리

### DIFF
--- a/example/demo-tailwind/src/pages/UseChatPG.tsx
+++ b/example/demo-tailwind/src/pages/UseChatPG.tsx
@@ -79,7 +79,7 @@ export default function UseChatPG() {
     gcTime: 60 * 10000
   });
 
-  const lastMessageEnd = messages[messages.length - 1]?.custom.end ? true : false;
+  const lastMessageEnd = messages[messages.length - 1]?.custom!.end ? true : false;
 
   return (
     <div className="max-w-xl mx-auto flex flex-col gap-4 p-4">
@@ -121,7 +121,9 @@ export default function UseChatPG() {
       <ChatList
         messages={messages}
         messageMapper={(msg) => ({
-          content: msg.custom.end === true ? "true입니당" : msg.content,
+          id: msg.id,
+          role: msg.role,
+          content: msg.custom!.end === true ? "true입니당" : msg.content,
         })}
         loadingRenderer={<SendingDots/>}
       />

--- a/src/components/ChatContainer.tsx
+++ b/src/components/ChatContainer.tsx
@@ -9,9 +9,9 @@ type MessageProps = {
   messageMapper?: never;
 };
 
-type RawProps<T> = {
-  messages: T[];
-  messageMapper: (msg: T) => Message;
+type RawProps<Raw> = {
+  messages: Raw[];
+  messageMapper: (msg: Raw) => Message;
 }
 
 type CommonProps = {
@@ -36,9 +36,9 @@ type CommonProps = {
   className?: string;
 };
 
-type Props<T> = CommonProps & (MessageProps | RawProps<T>);
+type Props<Raw> = CommonProps & (MessageProps | RawProps<Raw>);
 
-export default function ChatContainer<T>(props: Props<T>) {
+export default function ChatContainer<Raw>(props: Props<Raw>) {
   const [isAtBottom, setIsAtBottom] = useState(true);
   const scrollRef = useRef<HTMLDivElement>(null);
   const {

--- a/src/components/ChatList.tsx
+++ b/src/components/ChatList.tsx
@@ -1,19 +1,16 @@
-import type { BaseMessage, Message } from "../types/Message";
+import type { Message } from "../types/Message";
 import React from "react";
 import ChatMessage from "./ChatMessage";
 
-/* MessageMapper는 Message의 일부만 override */
-type MessagePatch = Partial<BaseMessage> & Record<string, unknown>;
-
-type Props<T extends Message = Message> = {
+type Props<Raw> = {
   /* 원본 메시지 배열 */
-  messages: T[];
+  messages: Raw[];
 
   /* Message 중 바꾸고 싶은 필드만 변환하는 함수 */
-  messageMapper?: (msg: T) => MessagePatch;
+  messageMapper?: (msg: Raw) => Message;
 
   /* 커스텀 메시지 UI를 사용하고 싶을 때 */
-  messageRenderer?: (msg: T) => React.ReactNode;
+  messageRenderer?: (msg: Message) => React.ReactNode;
 
   /* wrapper 커스텀 클래스 */
   className?: string;
@@ -21,23 +18,23 @@ type Props<T extends Message = Message> = {
   loadingRenderer?: React.ReactNode;
 };
 
-export default function ChatList<T extends Message>({
+export default function ChatList<Raw>({
   messages,
   messageMapper,
   messageRenderer,
   className,
   loadingRenderer,
-}: Props<T>) {
+}: Props<Raw>) {
   /*
   messages가 이미 MappedMessage 구조일 수도 있고 아닐 수도 있기 때문에
   messageMapper 여부에 따라 반환 처리
   */
-  const mappedMessages: T[] = messageMapper
+  const mappedMessages: Message[] = messageMapper
     ? messages.map((msg) => ({
       ...msg,
       ...messageMapper(msg),
       }))
-    : messages;
+    : (messages as unknown as Message[]);
 
   return (
     <div className={`flex flex-col ${className}`}>

--- a/src/components/indicators/LoadingSpinner.tsx
+++ b/src/components/indicators/LoadingSpinner.tsx
@@ -1,10 +1,10 @@
 type Size = 'xs' | 'sm' | 'md' | 'lg';
 
 type Props = {
-  size: Size;
-}
+  size?: Size;
+};
 
-export default function LoadingSpinner({ size }: Props) {
+export default function LoadingSpinner({ size = "md" }: Props) {
   const sizeMap: Record<Size, number> = {
     xs: 24,
     sm: 32,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,42 +1,31 @@
 import { useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import type { BaseMessage } from "../types/Message";
+import type { BaseMessage, Message, MessageCore } from "../types/Message";
 import { useState } from "react";
 
 /* Raw 데이터 중 Message에 매핑되지 않은 나머지 필드들 */
-type ExtraFromRaw<TRaw> = Omit<TRaw, keyof BaseMessage>;
+type ExtractCustom<Raw> = Omit<Raw, keyof BaseMessage>;
 
-/* 기본 Message 구조에 custom 필드를 추가한 확장 메시지 타입 */
-type CustomMessage<TCustom> = BaseMessage & {
-  custom: TCustom;
-};
-
-/* useChat 내부에서 최종적으로 사용하는 Message 타입 */
-type MessageMapper<TRaw> = CustomMessage<ExtraFromRaw<TRaw>>;
-
-/* 사용자가 map 함수에서 반드시 반환해야 하는 최소 Message 필드 */
-type MessageMapperResult = Pick<BaseMessage, "id" | "role" | "content">;
-
-type Options<TRaw> = {
+type Options<Raw> = {
   /* 해당 채팅의 queryKey */
   queryKey: readonly unknown[];
 
   /* 기존 채팅 내역을 가져오는 함수 */
-  queryFn: (pageParam: unknown) => Promise<TRaw[]>;
+  queryFn: (pageParam: unknown) => Promise<Raw[]>;
 
   /* 첫 페이지 번호 */
   initialPageParam: unknown;
   
   /* 다음 페이지를 가져오기 위한 pageParam 계산 함수 */
   getNextPageParam: (
-    lastPage: MessageMapper<TRaw>[],
-    allPages: MessageMapper<TRaw>[][]
+    lastPage: Message<ExtractCustom<Raw>>[],
+    allPages: Message<ExtractCustom<Raw>>[][]
   ) => unknown;
 
   /* 유저 입력(content)을 넘겨서 AI응답 1개를 받아오는 함수 */
-  mutationFn: (content: string) => Promise<TRaw>; 
+  mutationFn: (content: string) => Promise<Raw>; 
 
   /* raw 데이터를 Message로 변환하는 mapper */
-  map: (raw: TRaw) => MessageMapperResult;
+  map: (raw: Raw) => MessageCore;
 
   /* mutation 에러가 발생한 경우 외부에서 처리하고 싶을 때 사용하는 콜백 */
   onError?: (error: unknown) => void;
@@ -50,11 +39,11 @@ Raw 데이터와 map 결과를 분리하여
 map에 사용된 필드는 Message 최상위에 유지하고
 나머지 Raw 필드는 custom 객체로 수집하는 함수
 */
-function splitRawToMessage<TRaw extends object>(
-  raw: TRaw,
-  mapped: MessageMapperResult
-): CustomMessage<ExtraFromRaw<TRaw>> {
-  const custom = {} as ExtraFromRaw<TRaw>;
+function splitRawToMessage<Raw extends object>(
+  raw: Raw,
+  mapped: MessageCore
+): Message<ExtractCustom<Raw>> {
+  const custom = {} as ExtractCustom<Raw>;
   const mappedValues = new Set(Object.values(mapped));
 
   for (const [key, value] of Object.entries(raw)) {
@@ -69,7 +58,7 @@ function splitRawToMessage<TRaw extends object>(
   };
 }
 
-export default function useChat<TRaw extends object>({ 
+export default function useChat<Raw extends object>({ 
   queryKey, 
   queryFn, 
   initialPageParam,
@@ -79,7 +68,7 @@ export default function useChat<TRaw extends object>({
   onError, 
   staleTime = 0,
   gcTime = 0,
-}: Options<TRaw>) {
+}: Options<Raw>) {
   const [isPending, setIsPending] = useState<boolean>(false); // AI 응답 대기 상태
   const queryClient = useQueryClient();
 
@@ -90,7 +79,7 @@ export default function useChat<TRaw extends object>({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery<MessageMapper<TRaw>[]>({
+  } = useInfiniteQuery<Message<ExtractCustom<Raw>>[]>({
     queryKey,
     initialPageParam,
     queryFn: async ({ pageParam }) => {
@@ -105,19 +94,19 @@ export default function useChat<TRaw extends object>({
     gcTime,
   });
 
-  const messages: MessageMapper<TRaw>[] = data ? [...data.pages].reverse().flat() : [];
+  const messages: Message<ExtractCustom<Raw>>[] = data ? [...data.pages].reverse().flat() : [];
 
   const mutation = useMutation<
-    TRaw, 
+    Raw, 
     unknown, 
     string, 
-    { prev?: InfiniteData<MessageMapper<TRaw>[]> }
+    { prev?: InfiniteData<Message<ExtractCustom<Raw>>[]> }
   >({
     mutationFn, // (content: string) => Promise<TMutationRaw>
     onMutate: async (content) => {
       setIsPending(true);
 
-      const prev = queryClient.getQueryData<InfiniteData<MessageMapper<TRaw>[]>>(queryKey);
+      const prev = queryClient.getQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey);
       
       // 조건부 cancleQueries
       if (prev) {
@@ -125,7 +114,7 @@ export default function useChat<TRaw extends object>({
       }
 
       // query cache에 optimistic message를 직접 삽입
-      queryClient.setQueryData<InfiniteData<MessageMapper<TRaw>[]>>(queryKey, (old) => {
+      queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
         if (!old) return old;
 
         const pages = [...old.pages];
@@ -138,14 +127,14 @@ export default function useChat<TRaw extends object>({
             role: "USER",
             content,
             custom: {}
-          } as MessageMapper<TRaw>,
+          } as Message<ExtractCustom<Raw>>,
           {
             id: crypto.randomUUID(),
             role: "AI",
             content: "",
             isLoading: true,
             custom: {}
-          } as MessageMapper<TRaw>,
+          } as Message<ExtractCustom<Raw>>,
         ];
 
         return {
@@ -162,7 +151,7 @@ export default function useChat<TRaw extends object>({
       const mapped = map(rawAiResponse);
       const aiMessage = splitRawToMessage(rawAiResponse, mapped);
 
-      queryClient.setQueryData<InfiniteData<MessageMapper<TRaw>[]>>(queryKey, (old) => {
+      queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
         if (!old) return old;
 
         const pages = [...old.pages];

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -7,4 +7,9 @@ export type BaseMessage = {
   isLoading?: boolean;
 }
 
-export type Message<T = {}> = BaseMessage & T;
+// map 함수에서 반드시 반환해야 하는 최소 필드
+export type MessageCore = Pick<BaseMessage, "id" | "role" | "content">;
+
+export type Message<TCustom = unknown> = BaseMessage & {
+  custom?: TCustom;
+};


### PR DESCRIPTION
## 📌 Related Issue
#41 — **Message 타입 단일화 및 Raw 제네릭 네이밍 정리**

## 🚀 Description
- `Message.ts`에서 내부적으로 사용되던 여러 메시지 타입을 정리하고, 외부로는 `Message`타입만 노출하도록 구조를 단순화
- `useChat`, `useVoiceChat`에서 메시지 타입 의존성을 `Message` 기준으로 통일하여 API 사용성을 개선
- `Raw` 제네릭 네이밍을 명확히 정리해 매핑 로직의 가독성과 일관성을 향상

## 📸 Screenshot
내부 타입 및 로직 변경이므로 별도의 스크린샷 없음

## 📢 Notes
- `BaseMessage`, `MessageCore`는 내부 구현 전용 타입으로 유지하며 export 대상에서 제외
