### PR TITLE
fix: 컴포넌트 사용 시 CSS를 자동으로 로드하도록 빌드가 안 되는 문제 해결

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   splitting: false,
   sourcemap: false,
   clean: true,
+  injectStyle: true,
 });


### PR DESCRIPTION
## 📌 Related Issue
#47 — 컴포넌트 사용 시 CSS를 자동으로 로드하도록 빌드가 안 되는 문제 해결

## 🚀 Description
컴포넌트를 사용할 때 사용자가 별도의 CSS 파일을 import하지 않아도 스타일이 자동으로 적용되도록 라이브러리의 빌드 구조를 개선

- tsup의 injectStyle 옵션을 적용하여 컴포넌트 스타일을 런타임에 자동으로 주입하도록 변경 

## 📸 Screenshot
내부 코드 변경이므로 별도의 스크린샷 없음

## 📢 Notes

