### PR TITLE
refactor: Message 구조 분리 및 map 계약 강화

### DIFF
--- a/example/demo-tailwind/src/mocks/handlers.ts
+++ b/example/demo-tailwind/src/mocks/handlers.ts
@@ -22,7 +22,8 @@ export const handlers = [
           {
             chatId: `1${randomBoolean()}`, 
             sender: "user", 
-            body: "안녕하세요!"
+            body: "안녕하세요!",
+            timestamp: "1222",
           }, 
           {
             chatId: `2${randomBoolean()}`, 

--- a/example/demo-tailwind/src/pages/UseChatPG.tsx
+++ b/example/demo-tailwind/src/pages/UseChatPG.tsx
@@ -8,6 +8,7 @@ type Raw = {
   chatId: string;
   sender: "ai" | "user";
   body: string;
+  timestamp: string;
   end?: boolean;
 }
 

--- a/example/demo-tailwind/src/pages/UseChatPG.tsx
+++ b/example/demo-tailwind/src/pages/UseChatPG.tsx
@@ -52,7 +52,7 @@ export default function UseChatPG() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage
-  } = useChat<Raw>({
+  } = useChat({
     queryKey: ["chat", roomId],
     queryFn: (pageParam) => getChat(roomId, pageParam as number),
     initialPageParam: 0,
@@ -67,11 +67,14 @@ export default function UseChatPG() {
         throw new Error("강제 에러 발생 테스트");
       return sendAI(content);
     },
-    map: (raw) => ({
-      id: raw.chatId,
-      role: raw.sender === "ai" ? "AI" : "USER",
-      content: raw.body,
-    }),
+    map: {
+      id: "chatId",
+      role: "sender",
+      content: "body",
+    },
+    roleResolver: (sender) => {
+      return sender === "ai" ? "AI" : "USER"
+    },
     onError: (err) => {
       console.error(err);
       setErrorMessage("전송 중 오류가 발생했습니다.");
@@ -80,7 +83,7 @@ export default function UseChatPG() {
     gcTime: 60 * 10000
   });
 
-  const lastMessageEnd = messages[messages.length - 1]?.custom!.end ? true : false;
+  const lastMessageEnd = messages[messages.length - 1]?.custom?.end ? true : false;
 
   return (
     <div className="max-w-xl mx-auto flex flex-col gap-4 p-4">

--- a/example/demo-tailwind/src/pages/UseChatPG.tsx
+++ b/example/demo-tailwind/src/pages/UseChatPG.tsx
@@ -67,7 +67,7 @@ export default function UseChatPG() {
         throw new Error("강제 에러 발생 테스트");
       return sendAI(content);
     },
-    map: {
+    keyMap: {
       id: "chatId",
       role: "sender",
       content: "body",

--- a/example/demo-tailwind/src/pages/UseVoiceChatPG.tsx
+++ b/example/demo-tailwind/src/pages/UseVoiceChatPG.tsx
@@ -70,7 +70,7 @@ export default function UseVoiceChatPG() {
         throw new Error("강제 에러 발생 테스트");
       return sendAI(content);
     },
-    map: {
+    keyMap: {
       id: "chatId",
       role: "sender",
       content: "body",

--- a/example/demo-tailwind/src/pages/UseVoiceChatPG.tsx
+++ b/example/demo-tailwind/src/pages/UseVoiceChatPG.tsx
@@ -54,7 +54,7 @@ export default function UseVoiceChatPG() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage
-  } = useVoiceChat<Raw>({
+  } = useVoiceChat({
     voice: voice,
     queryKey: ["chat", roomId],
     queryFn: (pageParam) => getChat(roomId, pageParam as number),
@@ -70,11 +70,14 @@ export default function UseVoiceChatPG() {
         throw new Error("강제 에러 발생 테스트");
       return sendAI(content);
     },
-    map: (raw) => ({
-      id: raw.chatId,
-      role: raw.sender === "ai" ? "AI" : "USER",
-      content: raw.body,
-    }),
+    map: {
+      id: "chatId",
+      role: "sender",
+      content: "body",
+    },
+    roleResolver: (sender) => {
+      return sender === "ai" ? "AI": "USER"
+    },
     onError: (err) => {
       console.error(err);
       setErrorMessage("전송 중 오류가 발생했습니다.");
@@ -83,7 +86,7 @@ export default function UseVoiceChatPG() {
     gcTime: 60 * 10000
   });
 
-  const lastMessageEnd = messages[messages.length - 1]?.custom.end ? true : false;
+  const lastMessageEnd = messages[messages.length - 1]?.custom?.end ? true : false;
 
   return (
     <div className="max-w-xl mx-auto flex flex-col gap-4 p-4">
@@ -125,7 +128,9 @@ export default function UseVoiceChatPG() {
       <ChatList
         messages={messages}
         messageMapper={(msg) => ({
-          content: msg.custom.end === true ? "true입니당" : msg.content,
+          id: msg.id,
+          role: msg.role,
+          content: msg.custom!.end === true ? "true입니당" : msg.content,
         })}
         loadingRenderer={<SendingDots/>}
       />

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,78 +1,7 @@
 import { useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import type { Message, MessageCore } from "../types/Message";
 import { useState } from "react";
-
-/* =========================
- * 내부 전용 타입 & 유틸
- * ========================= */
-
-/* Raw 타입의 필드를 MessageCore(id, role, content)에 매핑하기 위한 키 정의 */
-type KeyMap<Raw extends Record<string, unknown>> = {
-  id: keyof Raw;
-  role: keyof Raw;
-  content: keyof Raw;
-}
-
-/* 
-Raw에서 MessageCore에 매핑된 필드를 제외한 나머지 필드
--> 최종 Message의 custom 영역
-*/
-type Custom<
-  Raw extends Record<string, unknown>,
-  Map extends KeyMap<Raw>
-> = Omit<Raw, Map["id" | "role" | "content"]>;
-
-/*
-Raw 데이터를 MessageCore로 변환
-- key 매핑은 컴파일 타임에 보장
-- role 값 변환은 roleResolver에서 처리
-*/
-function buildCore<
-  Raw extends Record<string, unknown>,
-  Map extends KeyMap<Raw>
->(
-  raw: Raw,
-  map: Map,
-  roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"]
-): MessageCore {
-  return {
-    id: raw[map.id] as MessageCore["id"],
-    role: roleResolver(raw[map.role]),
-    content: raw[map.content] as string,
-  };
-}
-
-/* 최종 Message 생성 */
-function buildMessage<
-  Raw extends Record<string, unknown>,
-  Map extends KeyMap<Raw>
->(
-  raw: Raw,
-  map: Map,
-  roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"]
-): Message<Custom<Raw, Map>> {
-  const core = buildCore(raw, map, roleResolver);
-  const custom = {} as Custom<Raw, Map>;
-
-  for (const key in raw) {
-    if (
-      key !== map.id &&
-      key !== map.role &&
-      key !== map.content
-    ) {
-      (custom as Record<string, unknown>)[key]= raw[key];
-    }
-  }
-
-  return {
-    ...core,
-    custom: custom as Custom<Raw, Map>,
-  };
-}
-
-/* =========================
- * Public API
- * ========================= */
+import { buildMessage, type Custom, type KeyMap } from "../internal/messageNormalizer";
 
 type Options<
   Raw extends Record<string, unknown>,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -52,20 +52,21 @@ function buildMessage<
   roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"]
 ): Message<Custom<Raw, Map>> {
   const core = buildCore(raw, map, roleResolver);
+  const custom = {} as Custom<Raw, Map>;
 
-  const custom = Object.keys(raw).reduce((acc, key) => {
-    if (!Object.values(map).includes(key as keyof Raw)) {
-      return {
-        ...acc,
-        [key]: raw[key as keyof Raw],
-      };
+  for (const key in raw) {
+    if (
+      key !== map.id &&
+      key !== map.role &&
+      key !== map.content
+    ) {
+      (custom as Record<string, unknown>)[key]= raw[key];
     }
-    return acc;
-  }, {} as Custom<Raw, Map>);
+  }
 
   return {
     ...core,
-    custom,
+    custom: custom as Custom<Raw, Map>,
   };
 }
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -27,7 +27,7 @@ type Options<
   mutationFn: (content: string) => Promise<Raw>; 
 
   /* raw 데이터를 Message로 변환하는 mapper */
-  map: Map;
+  keyMap: Map;
 
   /* Raw의 role 값을 내부 표준 role 타입으로 변환하는 함수 */
   roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"];
@@ -48,7 +48,7 @@ export default function useChat<
   initialPageParam,
   getNextPageParam,
   mutationFn,
-  map,
+  keyMap,
   roleResolver,
   onError, 
   staleTime = 0,
@@ -70,7 +70,7 @@ export default function useChat<
     queryFn: async ({ pageParam }) => {
       const rawList = await queryFn(pageParam);
       return rawList.map((raw) => 
-        buildMessage(raw, map, roleResolver)
+        buildMessage(raw, keyMap, roleResolver)
       );
     },
     getNextPageParam,
@@ -132,7 +132,7 @@ export default function useChat<
     },
     onSuccess: (rawAiResponse) => { 
       // 서버의 응답을 Message로 변환
-      const aiMessage = buildMessage(rawAiResponse, map, roleResolver);
+      const aiMessage = buildMessage(rawAiResponse, keyMap, roleResolver);
 
       queryClient.setQueryData<MessageInfiniteData<Raw, Map>>(queryKey, (old) => {
         if (!old) return old;

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,9 +1,70 @@
 import { useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import type { BaseMessage, Message, MessageCore } from "../types/Message";
+import type { Message, MessageCore } from "../types/Message";
 import { useState } from "react";
 
-/* Raw 데이터 중 Message에 매핑되지 않은 나머지 필드들 */
-type ExtractCustom<Raw> = Omit<Raw, keyof BaseMessage>;
+/* =========================
+ * 내부 전용 타입 & 유틸
+ * ========================= */
+
+// map 설계 결과
+type InternalMapResult<Raw extends object> = {
+  core: MessageCore;
+  usedKeys: readonly (keyof Raw)[];
+}
+
+// Raw에서 map이 소비한 필드를 제거해 custom 영역으로 계산
+type CustomFromKeys<Raw, K extends readonly (keyof Raw)[]> = Omit<Raw, K[number]>;
+
+// 사용자가 제공한 map을 실행해 내부 설계 정보로 승격
+function runMap<Raw extends object>(
+  raw: Raw,
+  map: (raw: Raw) => MessageCore
+): InternalMapResult<Raw> {
+  const core = map(raw);
+
+  // Raw 기준으로 core에 사용된 필드 추론
+  const usedKeys = Object.keys(raw).filter((key) => 
+    Object.values(core).includes((raw as any)[key])
+  ) as (keyof Raw)[];
+
+  return { core, usedKeys };
+}
+
+// InternalMapResult를 기반으로 최종 Message 생성
+function buildMessage<
+  Raw extends object,
+  K extends readonly (keyof Raw)[]
+>(
+  raw: Raw,
+  result: {
+    core: MessageCore,
+    usedKeys: K
+  }
+): Message<CustomFromKeys<Raw, K>> {
+  const custom = {} as CustomFromKeys<Raw, K>;
+
+  for (const key in raw) {
+    if (!result.usedKeys.includes(key as K[number])) {
+      (custom as any)[key] = raw[key];
+    }
+  }
+
+  // 위 코드의 "as any" 최소화 버전
+  // for (const key of Object.keys(raw) as (keyof Raw)[]) {
+  //   if (!result.usedKeys.includes(key as K[number])) {
+  //     custom[key as Exclude<keyof Raw, K[number]>] = raw[key];
+  //   }
+  // }
+
+  return {
+    ...result.core,
+    custom,
+  };
+}
+
+/* =========================
+ * Public API
+ * ========================= */
 
 type Options<Raw> = {
   /* 해당 채팅의 queryKey */
@@ -17,8 +78,8 @@ type Options<Raw> = {
   
   /* 다음 페이지를 가져오기 위한 pageParam 계산 함수 */
   getNextPageParam: (
-    lastPage: Message<ExtractCustom<Raw>>[],
-    allPages: Message<ExtractCustom<Raw>>[][]
+    lastPage: Message<any>[],
+    allPages: Message<any>[][]
   ) => unknown;
 
   /* 유저 입력(content)을 넘겨서 AI응답 1개를 받아오는 함수 */
@@ -33,30 +94,6 @@ type Options<Raw> = {
   staleTime?: number;
   gcTime?: number;
 };
-
-/* 
-Raw 데이터와 map 결과를 분리하여
-map에 사용된 필드는 Message 최상위에 유지하고
-나머지 Raw 필드는 custom 객체로 수집하는 함수
-*/
-function splitRawToMessage<Raw extends object>(
-  raw: Raw,
-  mapped: MessageCore
-): Message<ExtractCustom<Raw>> {
-  const custom = {} as ExtractCustom<Raw>;
-  const mappedValues = new Set(Object.values(mapped));
-
-  for (const [key, value] of Object.entries(raw)) {
-    if (!mappedValues.has(value)) {
-      (custom as any)[key] = value;
-    }
-  }
-
-  return {
-    ...mapped,
-    custom
-  };
-}
 
 export default function useChat<Raw extends object>({ 
   queryKey, 
@@ -79,14 +116,14 @@ export default function useChat<Raw extends object>({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery<Message<ExtractCustom<Raw>>[]>({
+  } = useInfiniteQuery<Message<any>[]>({
     queryKey,
     initialPageParam,
     queryFn: async ({ pageParam }) => {
-      const raw = await queryFn(pageParam);
-      return raw.map((r) => {
-        const mapped = map(r);
-        return splitRawToMessage(r, mapped);
+      const rawList = await queryFn(pageParam);
+      return rawList.map((raw) => {
+        const mapped = runMap(raw, map);
+        return buildMessage(raw, mapped);
       });
     },
     getNextPageParam,
@@ -94,19 +131,19 @@ export default function useChat<Raw extends object>({
     gcTime,
   });
 
-  const messages: Message<ExtractCustom<Raw>>[] = data ? [...data.pages].reverse().flat() : [];
+  const messages: Message<any>[] = data ? [...data.pages].reverse().flat() : [];
 
   const mutation = useMutation<
     Raw, 
     unknown, 
     string, 
-    { prev?: InfiniteData<Message<ExtractCustom<Raw>>[]> }
+    { prev?: InfiniteData<Message<any>[]> }
   >({
     mutationFn, // (content: string) => Promise<TMutationRaw>
     onMutate: async (content) => {
       setIsPending(true);
 
-      const prev = queryClient.getQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey);
+      const prev = queryClient.getQueryData<InfiniteData<Message<any>[]>>(queryKey);
       
       // 조건부 cancleQueries
       if (prev) {
@@ -114,7 +151,7 @@ export default function useChat<Raw extends object>({
       }
 
       // query cache에 optimistic message를 직접 삽입
-      queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
+      queryClient.setQueryData<InfiniteData<Message<any>[]>>(queryKey, (old) => {
         if (!old) return old;
 
         const pages = [...old.pages];
@@ -127,14 +164,14 @@ export default function useChat<Raw extends object>({
             role: "USER",
             content,
             custom: {}
-          } as Message<ExtractCustom<Raw>>,
+          } as Message<any>,
           {
             id: crypto.randomUUID(),
             role: "AI",
             content: "",
             isLoading: true,
             custom: {}
-          } as Message<ExtractCustom<Raw>>,
+          } as Message<any>,
         ];
 
         return {
@@ -148,10 +185,10 @@ export default function useChat<Raw extends object>({
     },
     onSuccess: (rawAiResponse) => { 
       // 서버의 응답을 Message로 변환
-      const mapped = map(rawAiResponse);
-      const aiMessage = splitRawToMessage(rawAiResponse, mapped);
+      const mapped = runMap(rawAiResponse, map);
+      const aiMessage = buildMessage(rawAiResponse, mapped);
 
-      queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
+      queryClient.setQueryData<InfiniteData<Message<any>[]>>(queryKey, (old) => {
         if (!old) return old;
 
         const pages = [...old.pages];

--- a/src/hooks/useVoiceChat.ts
+++ b/src/hooks/useVoiceChat.ts
@@ -28,7 +28,7 @@ type Options<
   mutationFn: (content: string) => Promise<Raw>; 
 
   /* raw 데이터를 Message로 변환하는 mapper */
-  map: Map;
+  keyMap: Map;
 
   /* Raw의 role 값을 내부 표준 role 타입으로 변환하는 함수 */
   roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"];
@@ -52,7 +52,7 @@ export default function useVoiceChat<
   initialPageParam,
   getNextPageParam,
   mutationFn,
-  map,
+  keyMap,
   roleResolver,
   voice,
   onError, 
@@ -77,7 +77,7 @@ export default function useVoiceChat<
     queryFn: async ({ pageParam }) => {
       const rawList = await queryFn(pageParam);
       return rawList.map((raw) => 
-        buildMessage(raw, map, roleResolver)  
+        buildMessage(raw, keyMap, roleResolver)  
       );
     },
     getNextPageParam,
@@ -138,7 +138,7 @@ export default function useVoiceChat<
     },
     onSuccess: (rawAiResponse) => { 
       // 서버의 응답을 Message로 변환
-      const aiMessage = buildMessage(rawAiResponse, map, roleResolver);
+      const aiMessage = buildMessage(rawAiResponse, keyMap, roleResolver);
 
       queryClient.setQueryData<MessageInfiniteData<Raw, Map>>(queryKey, (old) => {
         if (!old) return old;

--- a/src/hooks/useVoiceChat.ts
+++ b/src/hooks/useVoiceChat.ts
@@ -1,12 +1,14 @@
-import { useInfiniteQuery, useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import type { BaseMessage, Message, MessageCore } from "../types/Message";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { Message, MessageCore } from "../types/Message";
 import { useEffect, useRef, useState } from "react";
 import type { VoiceRecognition } from "../types/VoiceRecognition";
+import { buildMessage, type Custom, type KeyMap } from "../internal/messageNormalizer";
+import type { MessageInfiniteData, MessagePage } from "../internal/messageCacheTypes";
 
-/* Raw 데이터 중 Message에 매핑되지 않은 나머지 필드들 */
-type ExtractCustom<Raw> = Omit<Raw, keyof BaseMessage>;
-
-type Options<Raw> = {
+type Options<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw> = KeyMap<Raw>
+> = {
   /* 해당 채팅의 queryKey */
   queryKey: readonly unknown[];
 
@@ -18,15 +20,18 @@ type Options<Raw> = {
   
   /* 다음 페이지를 가져오기 위한 pageParam 계산 함수 */
   getNextPageParam: (
-    lastPage: Message<ExtractCustom<Raw>>[],
-    allPages: Message<ExtractCustom<Raw>>[][]
+    lastPage: MessagePage<Raw, Map>,
+    allPages: MessagePage<Raw, Map>[]
   ) => unknown;
 
   /* 유저 입력(content)을 넘겨서 AI응답 1개를 받아오는 함수 */
   mutationFn: (content: string) => Promise<Raw>; 
 
   /* raw 데이터를 Message로 변환하는 mapper */
-  map: (raw: Raw) => MessageCore
+  map: Map;
+
+  /* Raw의 role 값을 내부 표준 role 타입으로 변환하는 함수 */
+  roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"];
 
   /* 음성 입력을 제어하기 위한 컨트롤러(start / stop / transcript 연결) */
   voice: VoiceRecognition;
@@ -38,46 +43,26 @@ type Options<Raw> = {
   gcTime?: number;
 };
 
-/* 
-Raw 데이터와 map 결과를 분리하여
-map에 사용된 필드는 Message 최상위에 유지하고
-나머지 Raw 필드는 custom 객체로 수집하는 함수
-*/
-function splitRawToMessage<Raw extends object>(
-  raw: Raw,
-  mapped: MessageCore
-): Message<ExtractCustom<Raw>> {
-  const custom = {} as ExtractCustom<Raw>;
-  const mappedValues = new Set(Object.values(mapped));
-
-  for (const [key, value] of Object.entries(raw)) {
-    if (!mappedValues.has(value)) {
-      (custom as any)[key] = value;
-    }
-  }
-
-  return {
-    ...mapped,
-    custom
-  };
-}
-
-export default function useVoiceChat<Raw extends object>({ 
+export default function useVoiceChat<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw>
+>({ 
   queryKey, 
   queryFn, 
   initialPageParam,
   getNextPageParam,
   mutationFn,
   map,
+  roleResolver,
   voice,
   onError, 
   staleTime = 0,
   gcTime = 0,
-}: Options<Raw>) {
+}: Options<Raw, Map>) {
   const [isPending, setIsPending] = useState<boolean>(false); // AI 응답 대기 상태
   const queryClient = useQueryClient();
   const currentTextRef = useRef(""); // 음성 인식 중간 결과를 렌더링과 분리하기 위해 useRef 사용
-  const rollbackRef = useRef<InfiniteData<Message<ExtractCustom<Raw>>[]> | undefined>(undefined);
+  const rollbackRef = useRef<MessageInfiniteData<Raw, Map> | undefined>(undefined);
 
   // 내부적으로 queryFn(raw[]) -> Message[]로 변환해서 캐시에 저장
   const { 
@@ -86,15 +71,14 @@ export default function useVoiceChat<Raw extends object>({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery<Message<ExtractCustom<Raw>>[]>({
+  } = useInfiniteQuery<MessagePage<Raw, Map>>({
     queryKey,
     initialPageParam,
     queryFn: async ({ pageParam }) => {
-      const raw = await queryFn(pageParam);
-      return raw.map((r) => {
-        const mapped = map(r);
-        return splitRawToMessage(r, mapped);
-      });
+      const rawList = await queryFn(pageParam);
+      return rawList.map((raw) => 
+        buildMessage(raw, map, roleResolver)  
+      );
     },
     getNextPageParam,
     staleTime,
@@ -113,20 +97,20 @@ export default function useVoiceChat<Raw extends object>({
     Raw, 
     unknown, 
     string, 
-    { prev?: InfiniteData<Message<ExtractCustom<Raw>>[]> }
+    { prev?: MessageInfiniteData<Raw, Map> }
   >({
     mutationFn, // (content: string) => Promise<TMutationRaw>
     onMutate: async () => {
       setIsPending(true);
 
-      const prev = queryClient.getQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey);
+      const prev = queryClient.getQueryData<MessageInfiniteData<Raw, Map>>(queryKey);
       
       // 조건부 cancleQueries
       if (prev) {
         await queryClient.cancelQueries({ queryKey });
       }
 
-      queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
+      queryClient.setQueryData<MessageInfiniteData<Raw, Map>>(queryKey, (old) => {
         if (!old) return old;
 
         const pages = [...old.pages];
@@ -140,7 +124,7 @@ export default function useVoiceChat<Raw extends object>({
             content: "",
             isLoading: true,
             custom: {}
-          } as Message<ExtractCustom<Raw>>,
+          } as Message<Custom<Raw, Map>>,
         ];
 
         return {
@@ -154,10 +138,9 @@ export default function useVoiceChat<Raw extends object>({
     },
     onSuccess: (rawAiResponse) => { 
       // 서버의 응답을 Message로 변환
-      const mapped = map(rawAiResponse);
-      const aiMessage = splitRawToMessage(rawAiResponse, mapped);
+      const aiMessage = buildMessage(rawAiResponse, map, roleResolver);
 
-      queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
+      queryClient.setQueryData<MessageInfiniteData<Raw, Map>>(queryKey, (old) => {
         if (!old) return old;
 
         const pages = [...old.pages];
@@ -197,14 +180,14 @@ export default function useVoiceChat<Raw extends object>({
   const startRecording = async() => {
     currentTextRef.current = "";
 
-    const prev = queryClient.getQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey);
+    const prev = queryClient.getQueryData<MessageInfiniteData<Raw, Map>>(queryKey);
     rollbackRef.current = prev;
 
     if (prev) {
       await queryClient.cancelQueries({ queryKey });
     }
 
-    queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
+    queryClient.setQueryData<MessageInfiniteData<Raw, Map>>(queryKey, (old) => {
       if (!old) return old;
 
       const pages = [...old.pages];
@@ -217,7 +200,7 @@ export default function useVoiceChat<Raw extends object>({
           role: "USER",
           content: "",
           custom: {},
-        } as Message<ExtractCustom<Raw>>,
+        } as Message<Custom<Raw, Map>>,
       ];
 
       return {
@@ -233,7 +216,7 @@ export default function useVoiceChat<Raw extends object>({
   const onTranscript = (text: string) => {
     currentTextRef.current = text;
 
-    queryClient.setQueryData<InfiniteData<Message<ExtractCustom<Raw>>[]>>(queryKey, (old) => {
+    queryClient.setQueryData<MessageInfiniteData<Raw, Map>>(queryKey, (old) => {
       if (!old) return old;
 
       const pages = [...old.pages];

--- a/src/internal/messageCacheTypes.ts
+++ b/src/internal/messageCacheTypes.ts
@@ -1,0 +1,13 @@
+import type { InfiniteData } from "@tanstack/react-query";
+import type { Message } from "../types/Message";
+import type { Custom, KeyMap } from "./messageNormalizer";
+
+export type MessagePage<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw>
+> = Message<Custom<Raw, Map>>[];
+
+export type MessageInfiniteData<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw>
+> = InfiniteData<MessagePage<Raw, Map>>;

--- a/src/internal/messageNormalizer.ts
+++ b/src/internal/messageNormalizer.ts
@@ -1,0 +1,65 @@
+import type { Message, MessageCore } from "../types/Message";
+
+/* Raw 타입의 필드를 MessageCore(id, role, content)에 매핑하기 위한 키 정의 */
+export type KeyMap<Raw extends Record<string, unknown>> = {
+  id: keyof Raw;
+  role: keyof Raw;
+  content: keyof Raw;
+}
+
+/* 
+Raw에서 MessageCore에 매핑된 필드를 제외한 나머지 필드
+-> 최종 Message의 custom 영역
+*/
+export type Custom<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw>
+> = Omit<Raw, Map["id" | "role" | "content"]>;
+
+/*
+Raw 데이터를 MessageCore로 변환
+- key 매핑은 컴파일 타임에 보장
+- role 값 변환은 roleResolver에서 처리
+*/
+function buildCore<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw>
+>(
+  raw: Raw,
+  map: Map,
+  roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"]
+): MessageCore {
+  return {
+    id: raw[map.id] as MessageCore["id"],
+    role: roleResolver(raw[map.role]),
+    content: raw[map.content] as string,
+  };
+}
+
+/* 최종 Message 생성 */
+export function buildMessage<
+  Raw extends Record<string, unknown>,
+  Map extends KeyMap<Raw>
+>(
+  raw: Raw,
+  map: Map,
+  roleResolver: (value: Raw[Map["role"]]) => MessageCore["role"]
+): Message<Custom<Raw, Map>> {
+  const core = buildCore(raw, map, roleResolver);
+  const custom = {} as Custom<Raw, Map>;
+
+  for (const key in raw) {
+    if (
+      key !== map.id &&
+      key !== map.role &&
+      key !== map.content
+    ) {
+      (custom as Record<string, unknown>)[key]= raw[key];
+    }
+  }
+
+  return {
+    ...core,
+    custom: custom as Custom<Raw, Map>,
+  };
+}

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,5 +1,6 @@
-export type ChatRole = "AI" | "USER";
+type ChatRole = "AI" | "USER";
 
+// 라이브러리 내부에서 불변으로 보장되는 최소 메시지 구조
 export type BaseMessage = {
   id: number | string;
   role: ChatRole;
@@ -7,9 +8,12 @@ export type BaseMessage = {
   isLoading?: boolean;
 }
 
-// map 함수에서 반드시 반환해야 하는 최소 필드
+// 사용자가 map 함수에서 반드시 반환해야 하는 최소 필드
+// 해당 타입이 깨지면 컴파일 타임에 바로 에러
 export type MessageCore = Pick<BaseMessage, "id" | "role" | "content">;
 
+// 최종적으로 UI / 상태에서 사용되는 메시지 타입
+// custom은 map 설계에서 의도적으로 소비되지 않은 Raw 필드 영역
 export type Message<TCustom = unknown> = BaseMessage & {
   custom?: TCustom;
 };

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -1,7 +1,7 @@
 type ChatRole = "AI" | "USER";
 
 // 라이브러리 내부에서 불변으로 보장되는 최소 메시지 구조
-export type BaseMessage = {
+type BaseMessage = {
   id: number | string;
   role: ChatRole;
   content: string;


### PR DESCRIPTION
## 📌 Related Issue
#52 — Message 구조 분리 및 map 계약 강화

## 🚀 Description
### 1. map 기반 설계 전환 (함수 → 객체)
기존 구조는 아래와 같다.
- `map: (raw) => MessageCore` 형태의 **함수 기반 매핑**
- 타입 시스템은 map 내부를 알 수 없음
- 어떤 Raw 필드가 MessageCore로 소비되었는지 **컴파일 타임에 추적 불가**
- `custom` 필드 추출 책임이 전적으로 **런타임 값 비교(Set 기반)** 에 의존
```
const mappedValues = new Set(Object.values(mapped));
if (!mappedValues.has(value)) {
  custom[key] = value;
}
```
=> 완전히 **값 기반 런타임 정규화 구조**

따라서 `map`을 함수에서 객체 기반 `KeyMap`으로 전환했다.  
```
export type KeyMap<Raw> = {
  id: keyof Raw;
  role: keyof Raw;
  content: keyof Raw;
}
```
- 어떤  Raw 필드가 MessageCore에 매핑되는지 타입 시스템이 **키 레벨에서 인지 가능**
- `Custom<Raw, Map>`을 통해 **타입 레벨에서 custom 영역 계산**
```
export type Custom<
  Raw,
  Map extends KeyMap<Raw>
> = Omit<Raw, Map["id" | "role" | "content"]>;
```
=> `Raw → Message` 변환을  
**함수 기반 런타임 추론 구조**에서 **타입 기반 컴파일 타임 설계 엔진 구조**로 전환

> 또한, 설계 의도를 명확히 하기 위해 `map` 네이밍을 `keyMap`으로 변경함

**변경 전**
```
map: (raw) => ({
  id: raw.chatId,
  role: raw.sender === "ai" ? "AI" : "USER",
  content: raw.body,
}),
```

**변경 후**
```
keyMap: {
  id: "chatId",
  role: "sender",
  content: "body",
},
```
---

### 2. 책임 분리 명확화  
이번 변경은 **런타임 제거**가 목적이 아님

구조 판단은 타입 시스템이 담당하고,  
값 변환은 런타임이 담당하도록 **책임을 명확히 분리**  

| 단계 | 책임 |
|------|------|
| 어떤 필드가 core인지 판단 | 타입 시스템 (컴파일 타임) |
| role 값 변환 | 런타임 (roleResolver) |
| 실제 객체 생성 | 런타임 |

- 구조 안정성 → **컴파일 타임 보장**
- 값 변환 → **런타임 처리**

---

### 3. messageNormalizer 레이어 분리
정규화 로직을 `internal/messageNormalizer.ts`로 분리
- `KeyMap`
- `Custom`
- `buildCore`
- `buildMessage`

또한 캐시 타입을 명확히 하기 위해 아래 타입을 `internal/messageCacheTypes.ts`로 분리
- `Messagepage`
- `MessageInfiniteData`  

--- 

### 4. useChat / useVoiceChat 구조 통일  
- 동일한 KeyMap 기반 설계 적용
- 동일한 타입 기반 정규화 흐름 사용
- 캐시 타입 안정성 강화
- 제네릭 추론 정확도 향상  

---

### 변경 내용 정리
| 변경 전 | 변경 후 |
|--------|--------|
| map 함수 기반 | KeyMap 객체 기반 |
| 런타임 값 비교로 custom 추출 | 타입 레벨 Omit 계산 |
| 타입 시스템이 구조를 모름 | 타입 시스템이 구조를 인지 |
| splitRawToMessage 내부 값 기반 필터링 | buildMessage + Custom 타입 기반 정규화 |


## 📸 Screenshot
UI의 변경은 없으므로 별도의 스크린샷 없음

## 📢 Notes
- 공개 API는 유지되나 map 사용 방식이 변경됨 (함수 → 객체 + roleResolver 분리)
- 타입 안정성 및 제네릭 추론 품질이 크게 향상됨
- 향후 메시지 구조 확장 시 컴파일 타임 보호 범위가 넓어짐
- 정규화 계층이 독립되어 유지보수성과 확장성이 개선됨